### PR TITLE
Mistake in JS version prevents it from running

### DIFF
--- a/JavaScript/test.js
+++ b/JavaScript/test.js
@@ -31,7 +31,7 @@ try {
 		throw new Error("Please provide your application id and password!");
 	}
 	
-	if( imagePath == 'myFile.jpg') {
+	if( imagePath != 'myFile.jpg') {
 		throw new Error( "Please provide path to your image!")
 	}
 


### PR DESCRIPTION
There's a simple typo in the JS sample code that's preventing this from running. A `==` should be `!=`.
Before: 
![image](https://user-images.githubusercontent.com/8226037/113217444-f70da080-924b-11eb-8985-7033c8087a7d.png)

After:
![image](https://user-images.githubusercontent.com/8226037/113217490-05f45300-924c-11eb-9e1f-ab1b7df35452.png)
